### PR TITLE
Don't require URL field to be filled in

### DIFF
--- a/src/components/Add.js
+++ b/src/components/Add.js
@@ -211,16 +211,13 @@ export class Add extends PureComponent {
 
     submitOk() {
         const entry = this.entry;
-        return entry.title !== '' && entry.url !== '';
+        return entry.title !== '';
     }
 
     firstInvalid() {
         const entry = this.entry,
-            { title, url } = this.refs;
-        if (entry.title === '') {
-            return title;
-        }
-        return url;
+            { title } = this.refs;
+        return title;
     }
 
     handlePress(ev) {


### PR DESCRIPTION
Only the title is now checked for validity (not empty) in function `submitOk`, but not totally dismantling function `firstInvalid` for possible future extensions (right now, if anything is invalid, it is always title).

Unfortunately, I haven't been able to test this, because of my node.js/npm setup is not good enough; `gulp buildapp && npm run appinstall && gulp postclean` gives exit status 1. Could you build this? Then I'm happy to test it. :-)